### PR TITLE
Fixed syntax error

### DIFF
--- a/app/django/collector/settings.py
+++ b/app/django/collector/settings.py
@@ -61,7 +61,7 @@ SENSITIVITY = int(os.getenv('SENSITIVITY', -100))
 
 # The amount a device can be seen before being ignored
 DEVICE_IGNORE_THRESHOLD = int(os.getenv('DEVICE_IGNORE_THRESHOLD', 5000))
-EXCLUDE_IGNORED_DEVICES = string_to_bool(os.getenv('EXCLUDE_IGNORED_DEVICES', False)
+EXCLUDE_IGNORED_DEVICES = string_to_bool(os.getenv('EXCLUDE_IGNORED_DEVICES', False))
 
 # The threshold used for the signage page
 CAPACITY_THRESHOLD = int(os.getenv('CAPACITY_THRESHOLD', 10))


### PR DESCRIPTION
There is an unbalanced `)` that causes a fatal syntax error